### PR TITLE
incorrect cli switch in missing output error message

### DIFF
--- a/ble_dump.py
+++ b/ble_dump.py
@@ -101,7 +101,7 @@ if __name__ == '__main__':
   (opts, args) = init_opts(gr_block)
 
   if not opts.pcap_file:
-    print '\nerror: please specify pcap output file (-p)'
+    print '\nerror: please specify pcap output file (-o)'
     exit(1)
 
   # Verify BLE channels argument


### PR DESCRIPTION
error message says to use -p when PCAP_FILE is not specified, it actually is -o